### PR TITLE
fix: raise LexerError instead of crashing on malformed \u/\x string escapes

### DIFF
--- a/jugaadlang/lexer/lexer.py
+++ b/jugaadlang/lexer/lexer.py
@@ -336,15 +336,10 @@ class Lexer:
                     buf.append(escape_map[esc])
                 elif esc == "u":
                     # \uXXXX
-                    hex_chars = ""
-                    for _ in range(4):
-                        hex_chars += self._advance()
-                    buf.append(chr(int(hex_chars, 16)))
+                    buf.append(self._scan_hex_escape(4, "u", line, col))
                 elif esc == "x":
-                    hex_chars = ""
-                    for _ in range(2):
-                        hex_chars += self._advance()
-                    buf.append(chr(int(hex_chars, 16)))
+                    # \xXX
+                    buf.append(self._scan_hex_escape(2, "x", line, col))
                 else:
                     buf.append("\\")
                     buf.append(esc)
@@ -354,6 +349,36 @@ class Lexer:
         raw = "".join(buf)
         ttype = TokenType.FSTRING if is_fstring else TokenType.STRING
         return self._make(ttype, raw, line, col)
+
+    def _scan_hex_escape(self, n_digits: int, esc_char: str, line: int, col: int) -> str:
+        """Read `n_digits` hex digits for a \\u or \\x escape and return the decoded char.
+
+        Raises a proper LexerError (instead of letting IndexError/ValueError from
+        truncated or malformed escapes escape as raw Python exceptions) when the
+        source ends early or the digits aren't valid hex.
+        """
+        hex_chars = ""
+        for _ in range(n_digits):
+            if self._pos >= len(self.source):
+                raise LexerError(
+                    f"String khatam nahi hua (\\{esc_char} escape adhoora hai, "
+                    f"{n_digits} hex digits chahiye)",
+                    line,
+                    col,
+                    self._source_line_at(line),
+                )
+            hex_chars += self._advance()
+
+        try:
+            return chr(int(hex_chars, 16))
+        except ValueError:
+            raise LexerError(
+                f"Galat \\{esc_char} escape sequence: {hex_chars!r} "
+                f"({n_digits} hex digits hone chahiye)",
+                line,
+                col,
+                self._source_line_at(line),
+            ) from None
 
     # ── Number scanner ────────────────────────────────────────────────
 

--- a/jugaadlang/lexer/lexer.py
+++ b/jugaadlang/lexer/lexer.py
@@ -354,7 +354,7 @@ class Lexer:
         """Read `n_digits` hex digits for a \\u or \\x escape and return the decoded char.
 
         Raises a proper LexerError (instead of letting IndexError/ValueError from
-        truncated or malformed escapes escape as raw Python exceptions) when the
+        truncated or malformed escapes propagate as raw Python exceptions) when the
         source ends early or the digits aren't valid hex.
         """
         hex_chars = ""

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -2,8 +2,10 @@
 Tests for JugaadLang Lexer.
 """
 
+import pytest
+
 from jugaadlang.lexer.tokens import TokenType
-from jugaadlang.lexer.lexer import Lexer
+from jugaadlang.lexer.lexer import Lexer, LexerError
 
 
 def test_basic_tokens():
@@ -79,3 +81,19 @@ def test_string_escapes():
 
     assert tokens[0].type == TokenType.STRING
     assert tokens[0].value == "hello\nworld\tunicode☕"
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        '"\\u12"',  # truncated \u escape (source ends early)
+        '"\\x1"',  # truncated \x escape (source ends early)
+        '"\\uZZZZ"',  # \u with non-hex digits
+        '"\\xZZ"',  # \x with non-hex digits
+    ],
+)
+def test_malformed_unicode_escape_raises_lexer_error(src):
+    # Malformed \u / \x escapes must surface as a LexerError, not an
+    # unhandled IndexError/ValueError from the interpreter internals.
+    with pytest.raises(LexerError):
+        Lexer(src).tokenize()


### PR DESCRIPTION
## Bug

In `jugaadlang/lexer/lexer.py`, the string scanner's handling of `\u` and `\x` escape sequences did not validate its input. A truncated escape at end-of-source (e.g. `"\u12"`) raised a raw `IndexError`, and a non-hex escape (e.g. `"\xZZ"`, `"\uZZZZ"`) raised a raw `ValueError` — both bypassing the lexer's own `LexerError` mechanism (and its line/column/source-line context) that every other lexer failure path uses.

## Fix

Extracted the duplicated `\u`/`\x` parsing into a small `_scan_hex_escape` helper that checks source bounds before reading digits and validates the digits are valid hex, raising a proper `LexerError` with a clear message in both failure cases instead of letting the internal Python exception leak out.

## Testing

- Added parametrized regression tests in `tests/test_lexer.py` covering truncated and non-hex `\u`/`\x` escapes.
- `pytest tests/` passes (the one pre-existing failure, `test_cli_typecheck`, fails identically on `main` and is unrelated to this change).
- `ruff check` passes on the changed files.