### PR TITLE
feat(search): add spotlight search to docs navbar - closes #47

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1927,6 +1927,179 @@
       justify-content: center;
       gap: 0.5rem;
     }
+    /* =====================================================
+       SEARCH FEATURE — Issue #47
+       ===================================================== */
+
+    /* Nav search trigger */
+    .nav-search-trigger {
+      display: flex; align-items: center; gap: 0.5rem;
+      background: var(--bg-card, rgba(13,13,26,0.04));
+      border: 1px solid var(--border, rgba(0,0,0,0.08));
+      border-radius: 12px; padding: 0.35rem 0.75rem;
+      cursor: pointer; color: var(--text-muted, #8888AA);
+      font-family: inherit; font-size: 0.85rem; font-weight: 500;
+      transition: all 0.3s cubic-bezier(0.4,0,0.2,1);
+      white-space: nowrap;
+    }
+    .nav-search-trigger:hover {
+      border-color: var(--accent-saffron, #FF9933);
+      color: var(--accent-saffron, #FF9933);
+      background: rgba(255,153,51,0.08);
+      box-shadow: 0 0 0 3px rgba(255,153,51,0.1);
+    }
+    .search-kbd {
+      display: inline-flex; align-items: center;
+      background: var(--bg-tertiary, #EBEBEF);
+      border: 1px solid var(--border, rgba(0,0,0,0.08));
+      border-radius: 4px; padding: 0.1rem 0.35rem;
+      font-family: 'JetBrains Mono', monospace; font-size: 0.68rem;
+      color: var(--text-muted, #8888AA); line-height: 1.4;
+    }
+
+    /* Mobile search */
+    .mobile-search-trigger {
+      display: flex; align-items: center; gap: 0.75rem;
+      width: 100%; padding: 0.75rem 1rem;
+      background: var(--bg-card, rgba(13,13,26,0.04));
+      border: 1px solid var(--border, rgba(0,0,0,0.08));
+      border-radius: 12px; cursor: pointer;
+      color: var(--text-muted, #8888AA);
+      font-family: inherit; font-size: 0.9rem; font-weight: 500;
+      transition: all 0.3s cubic-bezier(0.4,0,0.2,1);
+      text-align: left; margin-top: 0.25rem;
+    }
+    .mobile-search-trigger:hover {
+      color: var(--accent-saffron, #FF9933);
+      border-color: var(--accent-saffron, #FF9933);
+      background: rgba(255,153,51,0.08);
+    }
+
+    /* Search overlay */
+    .search-overlay {
+      position: fixed; inset: 0; z-index: 9000;
+      background: rgba(0,0,0,0.55); backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+      display: flex; align-items: flex-start; justify-content: center;
+      padding-top: clamp(60px, 12vh, 120px);
+      opacity: 0; visibility: hidden;
+      transition: opacity 0.2s ease, visibility 0.2s ease;
+    }
+    .search-overlay.open { opacity: 1; visibility: visible; }
+
+    /* Search modal */
+    .search-modal {
+      width: 100%; max-width: 640px; margin: 0 1rem;
+      background: var(--bg-secondary, #fff);
+      border: 1px solid var(--border, rgba(0,0,0,0.08));
+      border-radius: 24px;
+      box-shadow: 0 24px 80px rgba(0,0,0,0.25), 0 0 0 1px rgba(255,153,51,0.1);
+      overflow: hidden;
+      transform: translateY(-16px) scale(0.97);
+      transition: transform 0.25s cubic-bezier(0.4,0,0.2,1);
+    }
+    .search-overlay.open .search-modal { transform: translateY(0) scale(1); }
+
+    .search-input-row {
+      display: flex; align-items: center; gap: 0.75rem;
+      padding: 0.9rem 1.25rem;
+      border-bottom: 1px solid var(--border, rgba(0,0,0,0.08));
+    }
+    .search-input-row .search-icon { color: var(--accent-saffron, #FF9933); flex-shrink: 0; }
+    #search-input {
+      flex: 1; background: transparent; border: none; outline: none;
+      font-family: inherit; font-size: 1.05rem; font-weight: 500;
+      color: var(--text-primary, #121224);
+      caret-color: var(--accent-saffron, #FF9933);
+    }
+    #search-input::placeholder { color: var(--text-muted, #8888AA); }
+    .search-close-btn {
+      background: var(--bg-card, rgba(13,13,26,0.04));
+      border: 1px solid var(--border, rgba(0,0,0,0.08));
+      border-radius: 4px; padding: 0.15rem 0.5rem;
+      font-family: 'JetBrains Mono', monospace; font-size: 0.7rem;
+      color: var(--text-muted, #8888AA); cursor: pointer;
+      transition: all 0.2s ease; flex-shrink: 0;
+    }
+    .search-close-btn:hover { color: var(--accent-saffron, #FF9933); border-color: var(--accent-saffron, #FF9933); }
+
+    /* Results */
+    .search-results-area {
+      max-height: 420px; overflow-y: auto; padding: 0.5rem;
+    }
+    .search-results-area::-webkit-scrollbar { width: 4px; }
+    .search-results-area::-webkit-scrollbar-thumb { background: var(--accent-saffron, #FF9933); border-radius: 4px; }
+
+    .search-section-label {
+      font-size: 0.7rem; font-weight: 700; letter-spacing: 0.1em;
+      text-transform: uppercase; color: var(--text-muted, #8888AA);
+      padding: 0.6rem 0.75rem 0.3rem;
+    }
+    .search-result-item {
+      display: flex; flex-direction: column; gap: 0.2rem;
+      padding: 0.65rem 0.85rem; border-radius: 12px; cursor: pointer;
+      border: 1px solid transparent; text-align: left;
+      width: 100%; background: transparent; font-family: inherit;
+      transition: all 0.2s ease;
+    }
+    .search-result-item:hover,
+    .search-result-item.kbd-active {
+      background: rgba(255,153,51,0.08);
+      border-color: rgba(255,153,51,0.25);
+    }
+    .search-result-item.kbd-active { border-color: rgba(255,153,51,0.45); }
+    .result-section-tag {
+      display: inline-flex; align-items: center; gap: 0.35rem;
+      font-size: 0.72rem; font-weight: 700;
+      color: var(--accent-saffron, #FF9933);
+      text-transform: uppercase; letter-spacing: 0.06em;
+    }
+    .result-section-tag::before {
+      content: ''; width: 6px; height: 6px; border-radius: 50%;
+      background: var(--accent-saffron, #FF9933); flex-shrink: 0;
+    }
+    .result-preview {
+      font-size: 0.875rem; color: var(--text-secondary, #555577);
+      line-height: 1.5; overflow: hidden;
+      display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+    }
+    .result-preview mark {
+      background: rgba(255,153,51,0.22); color: var(--accent-saffron, #FF9933);
+      font-weight: 700; border-radius: 3px; padding: 0 2px;
+      border-bottom: 1.5px solid rgba(255,153,51,0.45);
+    }
+
+    /* Empty / idle states */
+    .search-empty-state { padding: 3rem 2rem; text-align: center; color: var(--text-muted, #8888AA); }
+    .search-empty-state .empty-emoji { font-size: 2.5rem; display: block; margin-bottom: 0.75rem; }
+    .search-empty-state p { font-size: 0.9rem; line-height: 1.6; }
+    .search-empty-state strong { color: var(--text-secondary, #555577); }
+    .search-idle-state { padding: 2rem 1.5rem; text-align: center; color: var(--text-muted, #8888AA); font-size: 0.85rem; }
+    .search-idle-hints { display: flex; justify-content: center; gap: 1.5rem; flex-wrap: wrap; margin-top: 1rem; }
+    .search-idle-hint-item { display: flex; align-items: center; gap: 0.35rem; font-size: 0.78rem; }
+
+    /* Footer */
+    .search-footer {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0.6rem 1.25rem;
+      border-top: 1px solid var(--border, rgba(0,0,0,0.08));
+      font-size: 0.72rem; color: var(--text-muted, #8888AA);
+    }
+    .search-footer-hints { display: flex; gap: 1rem; }
+    .search-footer-hint { display: flex; align-items: center; gap: 0.3rem; }
+    .search-footer-hint kbd {
+      background: var(--bg-tertiary, #EBEBEF);
+      border: 1px solid var(--border, rgba(0,0,0,0.08));
+      border-radius: 4px; padding: 0.1rem 0.35rem;
+      font-family: 'JetBrains Mono', monospace; font-size: 0.65rem;
+      color: var(--text-muted, #8888AA);
+    }
+    .search-result-count { color: var(--accent-saffron, #FF9933); font-weight: 600; }
+
+    @media (max-width: 768px) {
+      .nav-search-trigger { display: none; }
+      .search-modal { margin: 0 0.5rem; }
+    }
   </style>
 </head>
 <body>
@@ -1958,6 +2131,22 @@
     <li><a href="#install">Install</a></li>
     <li><a href="#stdlib">Stdlib</a></li>
     <li><a href="https://github.com/JugaadLang/jugaadlang" class="nav-cta" target="_blank" rel="noopener"><svg class="github-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" focusable="false"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>GitHub <span id="github-stars-nav" class="github-stars-badge">↗</span></a></li>
+    <!-- Search trigger — Issue #47 -->
+    <li>
+      <button
+        id="nav-search-btn"
+        class="nav-search-trigger"
+        aria-label="Search documentation (Ctrl+K)"
+        aria-haspopup="dialog"
+        type="button"
+      >
+        <svg width="15" height="15" viewBox="0 0 15 15" fill="none" aria-hidden="true">
+          <path d="M10 6.5C10 8.433 8.433 10 6.5 10C4.567 10 3 8.433 3 6.5C3 4.567 4.567 3 6.5 3C8.433 3 10 4.567 10 6.5ZM9.394 10.101C8.644 10.664 7.712 11 6.5 11C4.015 11 2 8.985 2 6.5C2 4.015 4.015 2 6.5 2C8.985 2 11 4.015 11 6.5C11 7.712 10.664 8.644 10.101 9.394L12.854 12.146C13.049 12.342 13.049 12.658 12.854 12.854C12.658 13.049 12.342 13.049 12.146 12.854L9.394 10.101Z" fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"/>
+        </svg>
+        Search docs…
+        <span class="search-kbd" aria-hidden="true">⌘K</span>
+      </button>
+    </li>
     <li>
       <button class="theme-toggle" id="theme-toggle-desktop" aria-label="Toggle dark mode" type="button">
         <svg class="icon-sun" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
@@ -1978,6 +2167,13 @@
   <a href="#errors" onclick="closeMobileMenu()">Errors</a>
   <a href="#install" onclick="closeMobileMenu()">Install</a>
   <a href="#stdlib" onclick="closeMobileMenu()">Stdlib</a>
+  <!-- Mobile search trigger — Issue #47 -->
+  <button id="mobile-search-btn" class="mobile-search-trigger" type="button" aria-label="Search documentation">
+    <svg width="16" height="16" viewBox="0 0 15 15" fill="none" aria-hidden="true">
+      <path d="M10 6.5C10 8.433 8.433 10 6.5 10C4.567 10 3 8.433 3 6.5C3 4.567 4.567 3 6.5 3C8.433 3 10 4.567 10 6.5ZM9.394 10.101C8.644 10.664 7.712 11 6.5 11C4.015 11 2 8.985 2 6.5C2 4.015 4.015 2 6.5 2C8.985 2 11 4.015 11 6.5C11 7.712 10.664 8.644 10.101 9.394L12.854 12.146C13.049 12.342 13.049 12.658 12.854 12.854C12.658 13.049 12.342 13.049 12.146 12.854L9.394 10.101Z" fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"/>
+    </svg>
+    Search docs…
+  </button>
   <a href="https://github.com/JugaadLang/jugaadlang" class="mobile-github-link" target="_blank" rel="noopener"><svg class="github-icon" viewBox="0 0 16 16" width="18" height="18" fill="currentColor" focusable="false"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>GitHub <span id="github-stars-mobile">↗</span></a>
   <button class="theme-toggle mobile-theme-toggle" id="theme-toggle-mobile" aria-label="Toggle dark mode" type="button">
     <svg class="icon-sun" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
@@ -3567,6 +3763,323 @@ document.addEventListener('DOMContentLoaded', () => {
       applyTheme(e.matches ? 'dark' : 'light');
     }
   });
+})();
+</script>
+
+<!-- =====================================================
+     SEARCH MODAL — Issue #47
+     ===================================================== -->
+<div
+  id="search-overlay"
+  class="search-overlay"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Search JugaadLang documentation"
+  aria-hidden="true"
+>
+  <div class="search-modal" id="search-modal-box">
+    <div class="search-input-row">
+      <svg class="search-icon" width="18" height="18" viewBox="0 0 15 15" fill="none" aria-hidden="true">
+        <path d="M10 6.5C10 8.433 8.433 10 6.5 10C4.567 10 3 8.433 3 6.5C3 4.567 4.567 3 6.5 3C8.433 3 10 4.567 10 6.5ZM9.394 10.101C8.644 10.664 7.712 11 6.5 11C4.015 11 2 8.985 2 6.5C2 4.015 4.015 2 6.5 2C8.985 2 11 4.015 11 6.5C11 7.712 10.664 8.644 10.101 9.394L12.854 12.146C13.049 12.342 13.049 12.658 12.854 12.854C12.658 13.049 12.342 13.049 12.146 12.854L9.394 10.101Z" fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"/>
+      </svg>
+      <input
+        type="search"
+        id="search-input"
+        placeholder="Khojo kuch bhi… (agar, bolo, install, errors, stdlib…)"
+        autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+        aria-label="Search documentation"
+        aria-autocomplete="list"
+        aria-controls="search-results-list"
+      />
+      <button class="search-close-btn" id="search-close-btn" type="button" aria-label="Close search">Esc</button>
+    </div>
+    <div class="search-results-area" id="search-results-list" role="listbox" aria-label="Search results">
+      <div class="search-idle-state" id="search-idle-state">
+        <p>Kya dhundh rahe ho? 🇮🇳</p>
+        <div class="search-idle-hints">
+          <span class="search-idle-hint-item"><span class="search-kbd">↑↓</span> Navigate</span>
+          <span class="search-idle-hint-item"><span class="search-kbd">↵</span> Go to section</span>
+          <span class="search-idle-hint-item"><span class="search-kbd">Esc</span> Close</span>
+        </div>
+      </div>
+    </div>
+    <div class="search-footer">
+      <span id="search-result-count" class="search-result-count" aria-live="polite" aria-atomic="true"></span>
+      <div class="search-footer-hints">
+        <span class="search-footer-hint"><kbd>↑↓</kbd> Navigate</span>
+        <span class="search-footer-hint"><kbd>↵</kbd> Select</span>
+        <span class="search-footer-hint"><kbd>Esc</kbd> Close</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+/* =====================================================
+   Search Feature — Issue #47
+   Implements: search trigger, spotlight modal, full-text
+   index of all on-page sections (features, examples,
+   keywords, errors, stdlib, install, ecosystem, etc.)
+   ===================================================== */
+
+(function () {
+  'use strict';
+
+  /* ---- State ---- */
+  var searchIndex = [];
+  var kbdActiveIdx = -1;
+
+  /* ---- Helpers ---- */
+  function esc(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  /**
+   * buildSearchIndex()
+   * Walks every <section id="..."> on the page after DOM is ready.
+   * Collects text from headings, paragraphs, table cells, code,
+   * and list items — covering features, examples, keywords,
+   * errors, builtins, stdlib, install, ecosystem, and any
+   * future sections automatically.
+   */
+  function buildSearchIndex() {
+    searchIndex = [];
+    document.querySelectorAll('section[id]').forEach(function (section) {
+      var sectionId = section.id;
+      var titleEl = section.querySelector('h1,h2,h3');
+      var sectionTitle = titleEl ? titleEl.textContent.trim() : sectionId;
+
+      var parts = [];
+      var SELS = [
+        'h2','h3','h4','p','td','th','code','li',
+        '.feature-title','.feature-desc',
+        '.eco-title','.eco-desc',
+        '.keyword-chip','.code-block-body'
+      ];
+      SELS.forEach(function (sel) {
+        section.querySelectorAll(sel).forEach(function (el) {
+          var t = el.textContent.trim();
+          if (t.length > 2) parts.push(t);
+        });
+      });
+
+      var raw = parts.join(' ');
+      if (raw.length > 10) {
+        searchIndex.push({
+          sectionId: sectionId,
+          sectionTitle: sectionTitle,
+          raw: raw,
+          lc: raw.toLowerCase()
+        });
+      }
+    });
+  }
+
+  /**
+   * highlightText(text, query)
+   * Returns HTML-safe string with every case-insensitive match
+   * of query wrapped in <mark>.
+   */
+  function highlightText(text, query) {
+    if (!query) return esc(text);
+    var safeQ = esc(query).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return esc(text).replace(new RegExp(safeQ, 'gi'), function (m) {
+      return '<mark>' + m + '</mark>';
+    });
+  }
+
+  /**
+   * getSnippet(raw, query)
+   * Extracts ~160 chars of context around the first match.
+   */
+  function getSnippet(raw, query) {
+    var lc = raw.toLowerCase();
+    var qi = lc.indexOf(query.toLowerCase());
+    if (qi === -1) return raw.slice(0, 160) + (raw.length > 160 ? '\u2026' : '');
+    var start = Math.max(0, qi - 55);
+    var end = Math.min(raw.length, qi + query.length + 100);
+    return (start > 0 ? '\u2026' : '') + raw.slice(start, end) + (end < raw.length ? '\u2026' : '');
+  }
+
+  /**
+   * performSearch(query)
+   * Scores sections by occurrence frequency, shows top 30 results.
+   * Debounced at 120ms from the input handler.
+   */
+  function performSearch(query) {
+    var area = document.getElementById('search-results-list');
+    var countEl = document.getElementById('search-result-count');
+    kbdActiveIdx = -1;
+
+    var q = query.trim().toLowerCase();
+
+    if (!q) {
+      area.innerHTML =
+        '<div class="search-idle-state">' +
+        '<p>Kya dhundh rahe ho? \ud83c\uddee\ud83c\uddf3</p>' +
+        '<div class="search-idle-hints">' +
+        '<span class="search-idle-hint-item"><span class="search-kbd">\u2191\u2193</span> Navigate</span>' +
+        '<span class="search-idle-hint-item"><span class="search-kbd">\u21b5</span> Go to section</span>' +
+        '<span class="search-idle-hint-item"><span class="search-kbd">Esc</span> Close</span>' +
+        '</div></div>';
+      if (countEl) countEl.textContent = '';
+      return;
+    }
+
+    var safeQ = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp(safeQ, 'g');
+
+    var results = searchIndex
+      .map(function (entry) {
+        var matches = entry.lc.match(re);
+        return Object.assign({}, entry, { score: matches ? matches.length : 0 });
+      })
+      .filter(function (r) { return r.score > 0; })
+      .sort(function (a, b) { return b.score - a.score; })
+      .slice(0, 30);
+
+    if (!results.length) {
+      area.innerHTML =
+        '<div class="search-empty-state" role="status">' +
+        '<span class="empty-emoji">\ud83d\ude05</span>' +
+        '<p>Kuch nahi mila \u201c<strong>' + esc(query) + '</strong>\u201d<br/>' +
+        '<small>Try: agar, bolo, install, errors, stdlib, REPL\u2026</small></p>' +
+        '</div>';
+      if (countEl) countEl.textContent = '';
+      return;
+    }
+
+    if (countEl) countEl.textContent = results.length + ' result' + (results.length !== 1 ? 's' : '');
+
+    var html = '<div class="search-section-label">Results for \u201c' + esc(query) + '\u201d</div>';
+    results.forEach(function (r, idx) {
+      var snippet = getSnippet(r.raw, query);
+      html +=
+        '<button class="search-result-item" role="option"' +
+        ' data-section-id="' + esc(r.sectionId) + '"' +
+        ' data-result-idx="' + idx + '"' +
+        ' aria-label="Go to: ' + esc(r.sectionTitle) + '"' +
+        ' type="button">' +
+        '<span class="result-section-tag">' + esc(r.sectionTitle) + '</span>' +
+        '<span class="result-preview">' + highlightText(snippet, query) + '</span>' +
+        '</button>';
+    });
+    area.innerHTML = html;
+
+    area.querySelectorAll('.search-result-item').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        goToSection(btn.getAttribute('data-section-id'));
+      });
+    });
+  }
+
+  function goToSection(id) {
+    closeSearch();
+    var el = document.getElementById(id);
+    if (el) setTimeout(function () { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); }, 150);
+  }
+
+  function kbdNavigate(dir) {
+    var items = document.querySelectorAll('.search-result-item');
+    if (!items.length) return;
+    items.forEach(function (it) { it.classList.remove('kbd-active'); });
+    kbdActiveIdx = (kbdActiveIdx + dir + items.length) % items.length;
+    items[kbdActiveIdx].classList.add('kbd-active');
+    items[kbdActiveIdx].scrollIntoView({ block: 'nearest' });
+  }
+
+  /* ---- Open / Close ---- */
+  function openSearch() {
+    var overlay = document.getElementById('search-overlay');
+    var input = document.getElementById('search-input');
+    overlay.classList.add('open');
+    overlay.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+    setTimeout(function () { if (input) input.focus(); }, 80);
+  }
+
+  function closeSearch() {
+    var overlay = document.getElementById('search-overlay');
+    var input = document.getElementById('search-input');
+    overlay.classList.remove('open');
+    overlay.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+    if (input) { input.value = ''; performSearch(''); }
+    kbdActiveIdx = -1;
+  }
+
+  /* ---- Wire up events ---- */
+  function init() {
+    /* Build index — wait a tick so any JS-rendered content is in the DOM */
+    setTimeout(buildSearchIndex, 200);
+
+    var overlay  = document.getElementById('search-overlay');
+    var input    = document.getElementById('search-input');
+    var navBtn   = document.getElementById('nav-search-btn');
+    var mobBtn   = document.getElementById('mobile-search-btn');
+    var closeBtn = document.getElementById('search-close-btn');
+    var modalBox = document.getElementById('search-modal-box');
+    if (!overlay || !input) return;
+
+    if (navBtn)   navBtn.addEventListener('click', openSearch);
+    if (closeBtn) closeBtn.addEventListener('click', closeSearch);
+    if (mobBtn)   mobBtn.addEventListener('click', function () {
+      /* Close mobile menu first if open */
+      var mm = document.getElementById('mobile-menu');
+      var hb = document.getElementById('hamburger');
+      if (mm) mm.classList.remove('open');
+      if (hb) hb.classList.remove('open');
+      openSearch();
+    });
+
+    /* Click backdrop to close */
+    overlay.addEventListener('click', function (e) {
+      if (!modalBox.contains(e.target)) closeSearch();
+    });
+
+    /* Live search — debounced 120ms */
+    var debounce;
+    input.addEventListener('input', function () {
+      clearTimeout(debounce);
+      debounce = setTimeout(function () { performSearch(input.value); }, 120);
+    });
+
+    /* Global keyboard shortcuts */
+    document.addEventListener('keydown', function (e) {
+      var isOpen = overlay.classList.contains('open');
+
+      /* Ctrl+K / Cmd+K — toggle */
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault();
+        isOpen ? closeSearch() : openSearch();
+        return;
+      }
+      if (!isOpen) return;
+
+      switch (e.key) {
+        case 'Escape':    e.preventDefault(); closeSearch(); break;
+        case 'ArrowDown': e.preventDefault(); kbdNavigate(+1); break;
+        case 'ArrowUp':   e.preventDefault(); kbdNavigate(-1); break;
+        case 'Enter': {
+          e.preventDefault();
+          var active = document.querySelector('.search-result-item.kbd-active');
+          if (active) goToSection(active.getAttribute('data-section-id'));
+          break;
+        }
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
Implements the search functionality requested in #47.

## Changes
- **Search trigger** in the desktop navbar with a `Ctrl+K` / `⌘K` hint, styled to match the saffron theme
- **Mobile menu** search button - closes menu and opens modal
- **Spotlight-style modal** with blurred backdrop, scale-in animation, click-outside-to-close
- **Full-text index** built from every `<section id="...">` - covers Features, Examples, Keywords, Errors, Stdlib, Install, Ecosystem, and future sections automatically
- **Live search** debounced 120ms, ranked by frequency, up to 30 results
- **Highlighted matches** - wrapped in `<mark>` with saffron accent
- **Keyboard navigation** - `↑↓` navigate, `Enter` jump, `Esc` close
- **Dark mode** - uses existing CSS variables, works automatically

## Addresses issue requirements
-  Search bar at the top of the documentation
-  Filter documentation sections dynamically  
-  Highlight matching results

## Notes
Zero external dependencies — vanilla JS, no build step required.
