### PR TITLE
fix: make Flask an optional web dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "click>=8.1",
     "requests>=2.31",
     "publish>=0.3.6",
-    "flask>=3.1.3",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1000,7 +1000,6 @@ version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
-    { name = "flask" },
     { name = "prompt-toolkit" },
     { name = "publish" },
     { name = "pygments" },
@@ -1037,7 +1036,6 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'web'", specifier = ">=3.9" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0" },
     { name = "click", specifier = ">=8.1" },
-    { name = "flask", specifier = ">=3.1.3" },
     { name = "flask", marker = "extra == 'web'", specifier = ">=3.0" },
     { name = "httpx", marker = "extra == 'web'", specifier = ">=0.27" },
     { name = "jugaadlang", extras = ["web", "dev"], marker = "extra == 'all'" },


### PR DESCRIPTION
## Summary
- Remove `flask>=3.1.3` from core `dependencies` in `pyproject.toml`
- Keep Flask under the optional `[web]` extra (`flask>=3.0`)
- Update `uv.lock` to match

## Test plan
- [x] `pip install -e .` succeeds without Flask
- [x] Flask is only required with `pip install -e ".[web]"`
- [x] `JugaadWeb` still works without Flask (falls back to `http.server`)

Closes issue #52