### PR TITLE
feat: Add floating Back to Top button with smooth scroll

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1927,6 +1927,54 @@
       justify-content: center;
       gap: 0.5rem;
     }
+    /* ===== BACK TO TOP BUTTON ===== */
+    .back-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      width: 46px;
+      height: 46px;
+      border: none;
+      border-radius: var(--radius-full);
+      background: var(--gradient-saffron);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      box-shadow: var(--shadow-card);
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(16px);
+      transition: var(--transition);
+      z-index: 999;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      box-shadow: var(--shadow-glow);
+      transform: translateY(-3px);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--accent-saffron);
+      outline-offset: 2px;
+    }
+    .back-to-top svg {
+      width: 20px;
+      height: 20px;
+      stroke: currentColor;
+    }
+    @media (max-width: 768px) {
+      .back-to-top {
+        bottom: 1.25rem;
+        right: 1.25rem;
+        width: 42px;
+        height: 42px;
+      }
+    }
     /* =====================================================
        SEARCH FEATURE — Issue #47
        ===================================================== */
@@ -3181,7 +3229,33 @@
     </div>
   </div>
 </footer>
+<!-- ===== BACK TO TOP BUTTON ===== -->
+<button class="back-to-top" id="back-to-top" aria-label="Back to top" type="button">
+  <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="12" y1="19" x2="12" y2="5"></line>
+    <polyline points="5 12 12 5 19 12"></polyline>
+  </svg>
+</button>
 
+<script>
+// ===== BACK TO TOP BUTTON =====
+(function() {
+  const backToTopBtn = document.getElementById('back-to-top');
+  if (!backToTopBtn) return;
+
+  window.addEventListener('scroll', () => {
+    if (window.scrollY > 400) {
+      backToTopBtn.classList.add('visible');
+    } else {
+      backToTopBtn.classList.remove('visible');
+    }
+  });
+
+  backToTopBtn.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+})();
+</script>
 <!-- ===== JAVASCRIPT ===== -->
 <script>
 // ===== DATA =====


### PR DESCRIPTION
closes #64 
@Sumangal44 
## Description
Adds a floating "Back to Top" button to the website (`website/index.html`) so users don't have to manually scroll back up on long pages.

## Changes
- Added a fixed-position "Back to Top" button (bottom-right corner) with an up-arrow icon
- Button stays hidden by default and fades/slides into view only after the user scrolls down (~400px)
- Clicking the button smoothly scrolls the page back to the top (`window.scrollTo({ behavior: 'smooth' })`)
- Fully responsive — resizes for smaller screens via media query
- Accessible — includes `aria-label="Back to top"` and a visible focus outline for keyboard users
- Styled using the site's existing CSS variables, so it automatically matches both light and dark theme
- Implemented as a small, self-contained script — no existing functionality or files were changed

## Screenrecordings
**Before:**

https://github.com/user-attachments/assets/58ca46e1-5f1a-474d-819d-7b7aa57ef4c1



**After:**

https://github.com/user-attachments/assets/d0bd2b07-1f12-4a91-93fa-5a53f28f9b34



## Contribution
Submitting this as part of my ECSOC'26 open-source contribution.

Could a maintainer please review and add the appropriate labels to this PR? Thank you! 🙌
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/39aadfb2-967a-457c-a813-f8e255819dc6" />
