### PR TITLE
feat(events): implement event bus architecture (fixes #60)

### DIFF
--- a/jugaadlang/events/__init__.py
+++ b/jugaadlang/events/__init__.py
@@ -1,0 +1,3 @@
+from .bus import event_bus, EventBus
+
+__all__ = ["event_bus", "EventBus"]

--- a/jugaadlang/events/bus.py
+++ b/jugaadlang/events/bus.py
@@ -1,0 +1,52 @@
+from typing import Callable, Any, Dict, List
+
+class EventBus:
+    """
+    A simple singleton event bus for decoupling core modules (Lexer, Parser, Runtime)
+    using the observer pattern.
+    """
+    _instance = None
+
+    def __new__(cls) -> "EventBus":
+        if cls._instance is None:
+            cls._instance = super(EventBus, cls).__new__(cls)
+            cls._instance._subscribers = {}
+        return cls._instance
+
+    def subscribe(self, event_type: str, callback: Callable[[Dict[str, Any]], None]) -> None:
+        """Subscribe a callback to a specific event type."""
+        if event_type not in self._subscribers:
+            self._subscribers[event_type] = []
+        if callback not in self._subscribers[event_type]:
+            self._subscribers[event_type].append(callback)
+
+    def unsubscribe(self, event_type: str, callback: Callable[[Dict[str, Any]], None]) -> None:
+        """Unsubscribe a callback from a specific event type."""
+        if event_type in self._subscribers:
+            if callback in self._subscribers[event_type]:
+                self._subscribers[event_type].remove(callback)
+            if not self._subscribers[event_type]:
+                del self._subscribers[event_type]
+
+    def emit(self, event_type: str, data: Dict[str, Any] = None) -> None:
+        """Emit an event to all subscribed callbacks."""
+        if data is None:
+            data = {}
+        
+        # We use a copy of the list so that if a subscriber modifies the list,
+        # it doesn't break the current iteration.
+        callbacks = list(self._subscribers.get(event_type, []))
+        for callback in callbacks:
+            try:
+                callback(data)
+            except Exception as e:
+                # Event callbacks should not break the main execution flow
+                pass
+
+    def clear(self) -> None:
+        """Clear all subscribers (mostly used for testing)."""
+        self._subscribers.clear()
+
+
+# Global event bus instance
+event_bus = EventBus()

--- a/jugaadlang/lexer/lexer.py
+++ b/jugaadlang/lexer/lexer.py
@@ -74,7 +74,11 @@ class Lexer:
 
     def tokenize(self) -> list[Token]:
         """Return the full token list for the source."""
-        return list(self._generate())
+        from ..events.bus import event_bus
+        event_bus.emit("LEXING_STARTED", {"filename": self.filename, "source_length": len(self.source)})
+        tokens = list(self._generate())
+        event_bus.emit("LEXING_COMPLETED", {"filename": self.filename, "token_count": len(tokens)})
+        return tokens
 
     # ── Internal helpers ──────────────────────────────────────────────
 

--- a/jugaadlang/parser/parser.py
+++ b/jugaadlang/parser/parser.py
@@ -101,6 +101,8 @@ class Parser:
 
     def parse(self) -> Module:
         """Parse the entire token stream into a Module AST node."""
+        from ..events.bus import event_bus
+        event_bus.emit("PARSING_STARTED", {"filename": self._filename, "token_count": len(self._tokens)})
         body = []
         try:
             while not self._check(TokenType.EOF):
@@ -118,6 +120,7 @@ class Parser:
             curr = self._current_token()
             raise ParseError(f"Parser error occurred: {str(e)}", curr.line, curr.col)
 
+        event_bus.emit("PARSING_COMPLETED", {"filename": self._filename, "node_count": len(body)})
         return Module(body=body, line=1, col=1)
 
     # ── Token Navigation Helpers ──────────────────────────────────────

--- a/jugaadlang/runtime/interpreter.py
+++ b/jugaadlang/runtime/interpreter.py
@@ -241,6 +241,8 @@ class JugaadInterpreter:
 
     def run(self, source: str) -> None:
         """Run JugaadLang source code as statements (exec mode)."""
+        from ..events.bus import event_bus
+        event_bus.emit("EXECUTION_STARTED", {"filename": self.filename, "mode": "exec"})
         try:
             # 1. Lexical analysis
             lexer = Lexer(source, self.filename)
@@ -259,6 +261,7 @@ class JugaadInterpreter:
 
             # 5. Execute bytecode in the persistent namespace
             exec(code_obj, self.globals, self.globals)
+            event_bus.emit("EXECUTION_COMPLETED", {"filename": self.filename, "mode": "exec"})
         except Exception as e:
             # Print funny error message and re-raise / handle
             formatted = format_error(e, source, self.filename)
@@ -271,6 +274,8 @@ class JugaadInterpreter:
         If it's a single expression, evaluate and return its value (eval mode).
         Otherwise, execute as standard statements (exec mode).
         """
+        from ..events.bus import event_bus
+        event_bus.emit("EXECUTION_STARTED", {"filename": self.filename, "mode": "eval"})
         try:
             lexer = Lexer(source, self.filename)
             tokens = lexer.tokenize()
@@ -288,13 +293,16 @@ class JugaadInterpreter:
                 ast.fix_missing_locations(py_expr)
 
                 code_obj = compile(py_expr, self.filename, "eval")
-                return eval(code_obj, self.globals, self.globals)
+                result = eval(code_obj, self.globals, self.globals)
+                event_bus.emit("EXECUTION_COMPLETED", {"filename": self.filename, "mode": "eval"})
+                return result
             else:
                 # Compile and execute as a normal module block
                 transformer = JugaadToPythonTransformer(self.filename)
                 py_ast = transformer.transform(ast_mod)
                 code_obj = compile(py_ast, self.filename, "exec")
                 exec(code_obj, self.globals, self.globals)
+                event_bus.emit("EXECUTION_COMPLETED", {"filename": self.filename, "mode": "exec"})
                 return None
         except Exception as e:
             formatted = format_error(e, source, self.filename)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,58 @@
+import pytest
+from jugaadlang.events.bus import EventBus
+
+def test_event_bus_singleton():
+    bus1 = EventBus()
+    bus2 = EventBus()
+    assert bus1 is bus2
+
+def test_event_bus_subscribe_emit():
+    bus = EventBus()
+    bus.clear()
+
+    data_received = []
+
+    def callback(data):
+        data_received.append(data)
+
+    bus.subscribe("TEST_EVENT", callback)
+    bus.emit("TEST_EVENT", {"key": "value"})
+
+    assert len(data_received) == 1
+    assert data_received[0]["key"] == "value"
+
+def test_event_bus_unsubscribe():
+    bus = EventBus()
+    bus.clear()
+
+    data_received = []
+
+    def callback(data):
+        data_received.append(data)
+
+    bus.subscribe("TEST_EVENT", callback)
+    bus.unsubscribe("TEST_EVENT", callback)
+    bus.emit("TEST_EVENT", {"key": "value"})
+
+    assert len(data_received) == 0
+
+def test_event_bus_error_handling():
+    bus = EventBus()
+    bus.clear()
+
+    def callback_error(data):
+        raise ValueError("Oops")
+
+    data_received = []
+    def callback_ok(data):
+        data_received.append(data)
+
+    bus.subscribe("TEST_EVENT", callback_error)
+    bus.subscribe("TEST_EVENT", callback_ok)
+    
+    # Should not raise exception
+    bus.emit("TEST_EVENT", {"key": "value"})
+    
+    # callback_ok should still have been called (assuming order) or at least doesn't crash
+    # EventBus uses a list, so order is preserved. callback_error raises, but it is caught.
+    assert len(data_received) == 1


### PR DESCRIPTION
Closes #60

### Summary
Introduces a pub/sub EventBus architecture to JugaadLang to allow loose coupling between compiler components, enabling telemetry, debugging tools, and plugin systems.

### Motivation
To support future extensibility, debugging hooks, and telemetry, we need a way for core components (Lexer, Parser, Interpreter) to broadcast lifecycle events without tightly coupling them to consumers.

### Changes
- Created \jugaadlang/events/bus.py\: A singleton \EventBus\ class with \subscribe\, \unsubscribe\, and \emit\ methods.
- Modified \jugaadlang/lexer/lexer.py\: Emits \LEXING_STARTED\ and \LEXING_COMPLETED\ events.
- Modified \jugaadlang/parser/parser.py\: Emits \PARSING_STARTED\ and \PARSING_COMPLETED\ events.
- Modified \jugaadlang/runtime/interpreter.py\: Emits \EXECUTION_STARTED\ and \EXECUTION_COMPLETED\ events for both \exec\ and \eval\ modes.
- Created \	ests/test_events.py\: Added comprehensive unit tests covering subscription, emission, unsubscription, and error handling in callbacks.

### Acceptance Criteria
- [x] Create a singleton \EventBus\ class.
- [x] Implement \subscribe(event_name, callback)\ and \emit(event_name, data)\ methods.
- [x] Modify the Lexer to emit \LEXING_STARTED\ and \LEXING_COMPLETED\.
- [x] Modify the Parser to emit \PARSING_STARTED\ and \PARSING_COMPLETED\.
- [x] Modify the Interpreter/Compiler to emit \EXECUTION_STARTED\ and \EXECUTION_COMPLETED\.
- [x] Add unit tests for the event bus.

### Impact & Side Effects
No breaking changes or side effects. The event bus operates synchronously; consumers are responsible for their own performance. Callbacks that raise exceptions do not crash the event bus emission loop.

### How to Test
Run \pytest tests/test_events.py\ to verify event bus behavior.
Run \pytest tests/\ to ensure no regressions in core execution flow.

### Quality Checklist
- [x] Code follows project conventions.
- [x] Tests added and passing.
- [x] No scratch files or unrelated changes included.
