### PR TITLE
fix: read jug --version from package metadata

### DIFF
--- a/jug_cli/main.py
+++ b/jug_cli/main.py
@@ -9,6 +9,7 @@ import sys
 import ast
 from rich.console import Console
 
+from jugaadlang import __version__
 from jugaadlang.repl.repl import JugaadREPL
 from jugaadlang.runtime.interpreter import JugaadInterpreter
 from jugaadlang.package_manager.manager import JugaadPackageManager
@@ -18,7 +19,7 @@ console_stderr = Console(color_system="truecolor", force_terminal=True, stderr=T
 
 
 @click.group()
-@click.version_option(version="1.1.5", message="JugaadLang v%(version)s 🇮🇳")
+@click.version_option(version=__version__, message="JugaadLang v%(version)s 🇮🇳")
 def main() -> None:
     """JugaadLang — The Hindi-keyword programming language. 🚀"""
     pass


### PR DESCRIPTION
## Summary
`jug --version` was hardcoded as `1.1.5` in `jug_cli/main.py`, while the actual package version lives in `jugaadlang.__version__`. That can drift after version bumps.

## Why
`jug doctor` already uses `__version__`, but `--version` had its own hardcoded string. One source of truth is enough.

## Test plan
- [x] `jug --version` shows `JugaadLang v1.1.5`
- [x] Version matches `python -c "import jugaadlang; print(jugaadlang.__version__)"`

@Sumangal44 Small one-line fix, so I opened the PR directly without filing an issue. 
Happy to raise one if you prefer that workflow.