### PR TITLE
fix: check for mypy before invoking it in typecheck command (#96)

### DIFF
--- a/jug_cli/main.py
+++ b/jug_cli/main.py
@@ -210,8 +210,18 @@ def typecheck(file: str) -> None:
     """Type check a JugaadLang file using mypy."""
     import subprocess
     import tempfile
+    from importlib.util import find_spec
 
     console.print("[bold green]🕵️ JugaadLang Type Checker[/bold green]")
+
+    if find_spec("mypy") is None:
+        console.print(
+            "[bold red]✗ mypy is not installed.[/bold red]\n"
+            "mypy is required for type checking. Install it with:\n"
+            "  [cyan]pip install jugaadlang\\[dev][/cyan]"
+        )
+        sys.exit(1)
+
     console.print(f"Type checking [cyan]{file}[/cyan]...")
 
     try:


### PR DESCRIPTION
When mypy is not installed, jug typecheck now prints a clear error message asking the user to install it via pip install jugaadlang[dev], instead of misleadingly reporting 'Type check failed' with the raw 'No module named mypy' stderr output.

Uses ind_spec('mypy') guard, consistent with how jug doctor already checks for mypy.