### PR TITLE
feat(stdlib): add paath (text/string) module

### DIFF
--- a/jugaadlang/stdlib/paath.py
+++ b/jugaadlang/stdlib/paath.py
@@ -1,0 +1,59 @@
+"""
+paath — JugaadLang Text/String Module.
+"""
+
+
+def ulta(text: str) -> str:
+    """Reverse a string."""
+    return text[::-1]
+
+
+def palindrome_hai(text: str) -> bool:
+    """Check whether a string is a palindrome (case- and space-insensitive)."""
+    cleaned = text.replace(" ", "").lower()
+    return cleaned == cleaned[::-1]
+
+
+def shabd_gino(text: str) -> int:
+    """Count the words in a string."""
+    return len(text.split())
+
+
+def akshar_gino(text: str) -> int:
+    """Count the characters in a string."""
+    return len(text)
+
+
+def bada(text: str) -> str:
+    """Convert a string to uppercase."""
+    return text.upper()
+
+
+def chota(text: str) -> str:
+    """Convert a string to lowercase."""
+    return text.lower()
+
+
+def title_banao(text: str) -> str:
+    """Convert a string to title case."""
+    return text.title()
+
+
+def saaf(text: str) -> str:
+    """Trim leading and trailing whitespace from a string."""
+    return text.strip()
+
+
+def badlo(text: str, purana: str, naya: str) -> str:
+    """Replace all occurrences of a substring with another."""
+    return text.replace(purana, naya)
+
+
+def shamil_hai(text: str, khoj: str) -> bool:
+    """Check whether a string contains a substring."""
+    return khoj in text
+
+
+def dohrao(text: str, n: int) -> str:
+    """Repeat a string n times."""
+    return text * n

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -610,3 +610,60 @@ def test_crypto_module_re_exports() -> None:
     assert hasattr(crypto_module, "md5")
     assert hasattr(crypto_module, "base64_encode")
     assert hasattr(crypto_module, "base64_decode")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 18. Paath (Text/String)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestPaath:
+    """Tests for jug.stdlib.paath — text/string utilities."""
+
+    def test_ulta(self, interpreter: JugaadInterpreter) -> None:
+        import_module_via_interpreter(interpreter, "paath")
+        interpreter.run('x = paath.ulta("abc")')
+        assert interpreter.globals["x"] == "cba"
+
+    def test_palindrome_hai(self, interpreter: JugaadInterpreter) -> None:
+        import_module_via_interpreter(interpreter, "paath")
+        interpreter.run('a = paath.palindrome_hai("nayan")')
+        assert interpreter.globals["a"] is True
+        interpreter.run('b = paath.palindrome_hai("hello")')
+        assert interpreter.globals["b"] is False
+
+    def test_counts(self, interpreter: JugaadInterpreter) -> None:
+        import_module_via_interpreter(interpreter, "paath")
+        interpreter.run('w = paath.shabd_gino("ek do teen")')
+        assert interpreter.globals["w"] == 3
+        interpreter.run('c = paath.akshar_gino("abc")')
+        assert interpreter.globals["c"] == 3
+
+    def test_case_transforms(self, interpreter: JugaadInterpreter) -> None:
+        import_module_via_interpreter(interpreter, "paath")
+        interpreter.run('u = paath.bada("hi")')
+        assert interpreter.globals["u"] == "HI"
+        interpreter.run('l = paath.chota("HI")')
+        assert interpreter.globals["l"] == "hi"
+        interpreter.run('t = paath.title_banao("hello world")')
+        assert interpreter.globals["t"] == "Hello World"
+
+    def test_saaf(self, interpreter: JugaadInterpreter) -> None:
+        import_module_via_interpreter(interpreter, "paath")
+        interpreter.run('x = paath.saaf("  x  ")')
+        assert interpreter.globals["x"] == "x"
+
+    def test_badlo(self, interpreter: JugaadInterpreter) -> None:
+        import_module_via_interpreter(interpreter, "paath")
+        interpreter.run('x = paath.badlo("aXa", "X", "Y")')
+        assert interpreter.globals["x"] == "aYa"
+
+    def test_shamil_hai(self, interpreter: JugaadInterpreter) -> None:
+        import_module_via_interpreter(interpreter, "paath")
+        interpreter.run('x = paath.shamil_hai("hello", "ell")')
+        assert interpreter.globals["x"] is True
+
+    def test_dohrao(self, interpreter: JugaadInterpreter) -> None:
+        import_module_via_interpreter(interpreter, "paath")
+        interpreter.run('x = paath.dohrao("ab", 3)')
+        assert interpreter.globals["x"] == "ababab"


### PR DESCRIPTION
## What & why

Closes #105.

JugaadLang had no string-utility module. This adds `paath` — Hindi-named text helpers usable via `lao paath`.

## Changes

- **`jugaadlang/stdlib/paath.py`** — 11 pure functions: `ulta` (reverse), `palindrome_hai`, `shabd_gino` (word count), `akshar_gino` (char count), `bada`/`chota`/`title_banao` (case), `saaf` (trim), `badlo` (replace), `shamil_hai` (contains), `dohrao` (repeat). Stdlib-only, no side effects — mirrors the `crypto`/`ganit` module style. No registry change needed (`lao` transpiles to `import` and stdlib_path is already on sys.path).

## Testing

- Added a `TestPaath` class to `tests/test_stdlib.py` (8 cases) following the existing `TestGanit`/`TestCrypto` pattern (import via interpreter, assert on globals).
- `pytest` → **274 passed**; `ruff check` → **All checks passed**.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
